### PR TITLE
Fix IPFS abuse issues on hosting providers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -128,6 +128,8 @@ services:
   ipfs:
     image: ipfs/kubo:release
     profiles: ["ipfs"]
+    environment:
+      - IPFS_PROFILE=server
     entrypoint: >
       /bin/sh -c "
       echo 'adding cronjob';


### PR DESCRIPTION
### Checklist
- [x] My branch is up-to-date with upstream/main branch.

### Current behaviour
When IPFS container runs, it scans local network leading to abuse complaints on providers like Hetzner.

### New expected behaviour
Add `IPFS_PROFILE: server`

